### PR TITLE
Allow localization of Login text

### DIFF
--- a/action.php
+++ b/action.php
@@ -63,7 +63,7 @@ class action_plugin_authplaincas extends DokuWiki_Action_Plugin {
       $event->data->_content = array(); // remove the login form
       
       $event->data->insertElement(0,'<fieldset><legend>'.$this->getConf('name').'</legend>');
-      $event->data->insertElement(1,'<p style="text-align: center;">'.$caslogo.'<a href="'.$this->_selfdo('caslogin').'">Login</a></p>');
+      $event->data->insertElement(1,'<p style="text-align: center;">'.$caslogo.'<a href="'.$this->_selfdo('caslogin').'">'.$lang['btn_login'].'</a></p>');
       $event->data->insertElement(2,'</fieldset>');
       
       //instead of removing, one could implement a local login here...


### PR DESCRIPTION
Aside from supporting foreign languages, you can also use this to replace the
login text with things like "BRANDED ID Login", or "Login / Register" (if your
CAS login server provides registrations), via a
conf/lang/en/lang.php file.
