### PR TITLE
Add force_redirect feature

### DIFF
--- a/action.php
+++ b/action.php
@@ -104,9 +104,10 @@ class action_plugin_authplaincas extends DokuWiki_Action_Plugin {
   }
 
   function handle_action_after (&$event, $param){
-    global $ACT, $auth, $USERINFO;
+    global $ACT, $auth, $USERINFO, $MSG;
 
     if(
+        empty($MSG) &&
         (($ACT == 'denied' && empty($USERINFO)) || $ACT == 'login') &&
         $this->getConf('force_redirect') &&
         !($auth && $auth->canDo('modPass') && actionOK('resendpwd'))

--- a/conf/default.php
+++ b/conf/default.php
@@ -20,4 +20,4 @@ $conf['autologinout'] = 0;
 $conf['localusers'] = 0;
 $conf['minimalgroups'] = '';
 
-
+$conf['force_redirect'] = 0;

--- a/conf/metadata.php
+++ b/conf/metadata.php
@@ -19,3 +19,5 @@ $meta['autologinout'] = array('onoff');
 
 // $meta['localusers'] = array('onoff');
 $meta['minimalgroups'] = array('string');
+
+$meta['force_redirect'] = array('onoff');

--- a/lang/en/settings.php
+++ b/lang/en/settings.php
@@ -20,3 +20,5 @@ $lang['autologinout'] = 'login automatically and logout from CAS';
 
 $lang['localusers'] = 'Allow local users (authplain list) -> switch athentication to "authplain" to manage the userlist';
 $lang['minimalgroups'] = 'Comma separated list of groups of which a CAS user needs at least one to be created in the system. (group1, group2) leave empty to allow all users.';
+
+$lang['force_redirect'] = 'Redirect user to CAS if permission is required or ACT=login (no login message)';


### PR DESCRIPTION
This feature redirect users to CAS if:

- permission is required (`$ACT` = denied)
- or `$ACT` = login (no login page on DokuWiki will be shown except `$auth` can `resendpwd`, and thus user don't need to click CAS login on login page to go to CAS)

It's off by default, and can be turned on by config `force_redirect`.