### PR TITLE
making CAS logo clickable as part of login link

### DIFF
--- a/action.php
+++ b/action.php
@@ -63,7 +63,7 @@ class action_plugin_authplaincas extends DokuWiki_Action_Plugin {
       $event->data->_content = array(); // remove the login form
       
       $event->data->insertElement(0,'<fieldset><legend>'.$this->getConf('name').'</legend>');
-      $event->data->insertElement(1,'<p style="text-align: center;">'.$caslogo.'<a href="'.$this->_selfdo('caslogin').'">'.$lang['btn_login'].'</a></p>');
+      $event->data->insertElement(1,'<p style="text-align: center;"><a href="'.$this->_selfdo('caslogin').'"><div>'.$caslogo.'</div>'.$lang['btn_login'].'</a></p>');
       $event->data->insertElement(2,'</fieldset>');
       
       //instead of removing, one could implement a local login here...


### PR DESCRIPTION
I think the CAS logo should be clickable for logging in, otherwise the small "Log In" link underneath it gets dwarfed and users often don't notice it.