### PR TITLE
Check $MSG is visible to current user for force_redirect

### DIFF
--- a/action.php
+++ b/action.php
@@ -107,12 +107,21 @@ class action_plugin_authplaincas extends DokuWiki_Action_Plugin {
     global $ACT, $auth, $USERINFO, $MSG;
 
     if(
-        empty($MSG) &&
         (($ACT == 'denied' && empty($USERINFO)) || $ACT == 'login') &&
         $this->getConf('force_redirect') &&
         !($auth && $auth->canDo('modPass') && actionOK('resendpwd'))
-      ) {
-      $this->handle_caslogin(); // will jump out if redirect is required
+      ){
+        // check $MSG
+        if(is_array($MSG)){
+            foreach ($MSG as $m) {
+              if($m && info_msg_allowed($m)){
+                return;
+                // Has messages, don't execute the redirector below
+              }
+            }
+        }
+
+        $this->handle_caslogin(); // will jump out if redirect is required
     }
   }
 


### PR DESCRIPTION
Thanks for merging force redirecting feature first 😄. That code is written by me months ago, and we have been using this in production nicely.
However, I found a issue with the $MSG check, which may prevent the auto redirecting when there is `$MSG` not visible to the current user. This patch will fix this.