### PR TITLE
Allow wiki admins to Edit Groups through the Wiki

### DIFF
--- a/auth.php
+++ b/auth.php
@@ -97,7 +97,7 @@ class auth_plugin_authplaincas extends DokuWiki_Auth_Plugin {
       $this->cando['modPass']      = false;
       $this->cando['modName']      = false;
       $this->cando['modMail']      = false;
-      $this->cando['modGroups']    = false;
+      $this->cando['modGroups']    = true;
       $this->cando['getUsers']     = true;
       $this->cando['getUserCount'] = true;
 


### PR DESCRIPTION
Wiki-defined groups are still used for wiki ACL, CAS doesn't provide granular group permissions