### PR TITLE
Fix redirect on login

### DIFF
--- a/auth.php
+++ b/auth.php
@@ -243,7 +243,8 @@ class auth_plugin_authplaincas extends DokuWiki_Auth_Plugin {
   }
 
   public function logIn() {
-    $login_url = DOKU_URL . 'doku.php?id=' . $_GET["id"];
+    global $ID;
+    $login_url = wl($ID,'',true);
     phpCAS::setFixedServiceURL($login_url);
     phpCAS::forceAuthentication();
   }
@@ -252,7 +253,8 @@ class auth_plugin_authplaincas extends DokuWiki_Auth_Plugin {
     if($this->_getOption('handlelogoutrequest')) { // dokuwiki + cas logout
       @session_start();
       session_destroy();
-      $logout_url = DOKU_URL . 'doku.php';
+      global $ID;
+      $logout_url = wl($ID,'',true);
       //hide warnings of not initalized session, cas session is killed anyway
       @phpCAS::logoutWithRedirectService($logout_url);
     }

--- a/auth.php
+++ b/auth.php
@@ -243,19 +243,16 @@ class auth_plugin_authplaincas extends DokuWiki_Auth_Plugin {
   }
 
   public function logIn() {
-    global $QUERY;
-    $login_url = DOKU_URL . 'doku.php?id=' . $QUERY;
+    $login_url = DOKU_URL . 'doku.php?id=' . $_GET["id"];
     phpCAS::setFixedServiceURL($login_url);
     phpCAS::forceAuthentication();
   }
 
   public function logOff() {
-    global $QUERY;
-
     if($this->_getOption('handlelogoutrequest')) { // dokuwiki + cas logout
       @session_start();
       session_destroy();
-      $logout_url = DOKU_URL . 'doku.php?id=' . $QUERY;
+      $logout_url = DOKU_URL . 'doku.php';
       //hide warnings of not initalized session, cas session is killed anyway
       @phpCAS::logoutWithRedirectService($logout_url);
     }


### PR DESCRIPTION
The `$QUERY` variable seems to contain nothing.

Reading the GET parameter `id` works for me, even with the [userewrite](https://www.dokuwiki.org/config:userewrite) configuration option enabled.