### PR TITLE
Update auth.php

### DIFF
--- a/auth.php
+++ b/auth.php
@@ -243,19 +243,19 @@ class auth_plugin_authplaincas extends DokuWiki_Auth_Plugin {
   }
 
   public function logIn() {
-    global $QUERY;
-    $login_url = DOKU_URL . 'doku.php?id=' . $QUERY;
+    global $ID;
+    $login_url = DOKU_URL . 'doku.php?id=' . $ID;
     phpCAS::setFixedServiceURL($login_url);
     phpCAS::forceAuthentication();
   }
 
   public function logOff() {
-    global $QUERY;
+    global $ID;
 
     if($this->_getOption('handlelogoutrequest')) { // dokuwiki + cas logout
       @session_start();
       session_destroy();
-      $logout_url = DOKU_URL . 'doku.php?id=' . $QUERY;
+      $logout_url = DOKU_URL . 'doku.php?id=' . $ID;
       //hide warnings of not initalized session, cas session is killed anyway
       @phpCAS::logoutWithRedirectService($logout_url);
     }


### PR DESCRIPTION
Replace $QUERY global with $ID global as per https://www.dokuwiki.org/devel:environment#id
This redirects properly on login to the page the user was trying to access before logging in